### PR TITLE
Added blacklist for nodes

### DIFF
--- a/neighbors.js
+++ b/neighbors.js
@@ -1,6 +1,6 @@
 const Edge = require('./Edge')
 
-function neighbors (node, { blacklist, dirIn, dirOut = true, followLiterals, whitelist } = {}) {
+function neighbors (node, { blacklist, dirIn, dirOut = true, followLiterals, whitelist, nodeBlacklist } = {}) {
   if (blacklist && whitelist) {
     throw new Error('blacklist or whitelist must be given, not both at the same time')
   }
@@ -14,6 +14,10 @@ function neighbors (node, { blacklist, dirIn, dirOut = true, followLiterals, whi
       }
 
       if (whitelist && !whitelist.has(quad.predicate)) {
+        return
+      }
+
+      if (nodeBlacklist && (nodeBlacklist.has(quad.object)||nodeBlacklist.has(quad.subject))) {
         return
       }
 
@@ -32,6 +36,10 @@ function neighbors (node, { blacklist, dirIn, dirOut = true, followLiterals, whi
       }
 
       if (whitelist && !whitelist.has(quad.predicate)) {
+        return
+      }
+
+      if (nodeBlacklist && (nodeBlacklist.has(quad.object)||nodeBlacklist.has(quad.subject))) {
         return
       }
 

--- a/shortest.js
+++ b/shortest.js
@@ -2,7 +2,7 @@ const neighbors = require('./neighbors')
 const Path = require('./Path')
 const TermSet = require('@rdfjs/term-set')
 
-function shortest (start, end, { blacklist, cutoff = Number.MAX_SAFE_INTEGER, dirIn, dirOut = true, followLiterals, whitelist } = {}) {
+function shortest (start, end, { blacklist, cutoff = Number.MAX_SAFE_INTEGER, dirIn, dirOut = true, followLiterals, whitelist, nodeBlacklist } = {}) {
   if (blacklist && whitelist) {
     throw new Error('blacklist or whitelist must be given, not both at the same time')
   }
@@ -14,7 +14,7 @@ function shortest (start, end, { blacklist, cutoff = Number.MAX_SAFE_INTEGER, di
     const next = []
 
     for (const path of todo) {
-      const edges = neighbors(path.end || start, { blacklist, dirIn, dirOut, followLiterals, whitelist })
+      const edges = neighbors(path.end || start, { blacklist, dirIn, dirOut, followLiterals, whitelist, nodeBlacklist })
 
       for (const edge of edges) {
         if (done.has(edge.end.term)) {


### PR DESCRIPTION
Added new input for array of blacklisted nodes. This functionality is in addition to the blacklist of predicates. You can now avoid certain nodes when finding the path.

The array for avoiding nodes works the same way as the array for avoiding predicates.